### PR TITLE
Mininum javac version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool is for creating a visualization of the warnings/defects that were gene
 * The project that is going to be analyzed must support the execution of ASATs. We support FindBugs, Checkstyle, PMD. 
 
 ## Building
-* Make sure your java compiler is higher than 1.8.0_45. You can check this by doing `javac -version`.
+* Make sure your java compiler is higher than 1.8.0_40. You can check this by doing `javac -version`.
 * Run `mvn package`.
 * If you want to develop UAV, please install Lombok to auto-generate getters and setters. (Via `java -jar lib/lombok.jar install path/to/your/ide`)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This tool is for creating a visualization of the warnings/defects that were gene
 * The project that is going to be analyzed must support the execution of ASATs. We support FindBugs, Checkstyle, PMD. 
 
 ## Building
+* Make sure your java compiler is higher than 1.8.0_45. You can check this by doing `javac -version`.
 * Run `mvn package`.
 * If you want to develop UAV, please install Lombok to auto-generate getters and setters. (Via `java -jar lib/lombok.jar install path/to/your/ide`)
 


### PR DESCRIPTION
Adding information on README file about the minimum javac version required (the project uses javafx Alert class, which was introduced in 1.8.0_45)