### PR TITLE
Document Minimal Java requirements and enforce build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tool is for creating a visualization of the warnings/defects that were gene
 
 ## Requirements:
 * One of the following internet browsers: Google Chrome or Safari.
-* Java JDK 1.8 (or higher).
+* Java JDK 1.8 (Update 40 or higher).
 * ASATs version:
   * Checkstyle 6.1.1, PMD 5.2.3 and FindBugs 3.0.1. (CheckStyle 6.17 and PMD version 5.3.2 also work).
 * Users must have Maven (IDE plugin or standalone app) installed to run `mvn site`.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,18 @@ This tool is for creating a visualization of the warnings/defects that were gene
 
 ## Building
 * Run `mvn package`.
-* If you want to develop UAV, please install Lombok to auto-generate getters and setters. (Via `java -jar lib/lombok.jar install path/to/your/ide`)
+* If you want to contribute to UAV's development, please install Lombok to auto-generate getters and setters. (Via `java -jar lib/lombok.jar install path/to/your/ide`)
 
 ## Running the Program:
+Running UAV is simple: After building it, the latest executable Jar has been conviently placed in the project's base folder. All you have to do is:
+* Start UAV via `java -jar UnifiedASATVisualizer-1.1.2.jar`
+* Follow the instruction on UAV's User Interface.
+* Select the top-level project directory (on your computer) that you want to visualize.
+* Click the `Visualize` button. Depending on the project's size and number of warnings, this may take some time to generate the HTML visualization.
+* If the visualization does not open automatically (known problems with Linux) or the Java application appears to have crashed, manually open ./visualization/main.html in Chrome or Safari.
+
+UAV requires you to run on a Java project with ASAT warnings generated via `maven site`. Many famous projects include this already, but if you want to analyze a project which does not, here is how you do it:
+
 * Add the following snippet to the project's pom.xml file that you want to analyze:
 
 ```XML
@@ -57,8 +66,4 @@ This tool is for creating a visualization of the warnings/defects that were gene
 Copy the whole snippet **only** if you do not have `<reporting>` in your pom.xml. If you do, then just copy the plugins. For more information on how to exclude certain files or how to use specific rulesets, please check the following links: ([FindBugs](http://gleclaire.github.io/findbugs-maven-plugin/usage.html), [CheckStyle](https://maven.apache.org/plugins/maven-checkstyle-plugin/usage.html), [PMD](https://maven.apache.org/plugins/maven-pmd-plugin/usage.html))
 
 * Run `mvn site` on the project you want to analyze (this generates the ASAT reports which are read-in by UAV).
-* Start UAV via `java -jar uav.jar`
-* Follow the instruction on UAV's User Interface.
-* Select the top-level project directory (on your computer) that you want to visualize.
-* Click the `Visualize` button. Depending on the project's size and number of warnings, this may take some time to generate the HTML visualization.
-* If the visualization does not open automatically (known problems with Linux) or the Java application appears to have crashed, try manually opnening visualization/main.html in Chrome or Safari.
+

--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,13 @@
 					<goal>shade</goal>
 				</goals>
 				<configuration>
+				  <outputFile>./${project.artifactId}-${project.version}.jar</outputFile>
 				  <transformers>
 					<!-- add Main-Class to manifest file -->
-   	                       <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-						   <mainClass>BlueTurtle.uav.Main</mainClass>
-				           </transformer>
+   					<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+					  <mainClass>BlueTurtle.uav.Main</mainClass>
+				        </transformer>
 				  </transformers>
-				  <outputDirectory>${basedir}</outputDirectory>
 				</configuration>
 			   </execution>
 			  </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,28 @@
     			</executions>
 			</plugin>
 
+			<plugin>
+			  <groupId>org.apache.maven.plugins</groupId>
+			  <artifactId>maven-enforcer-plugin</artifactId>
+			  <version>1.4.1</version>
+			  <executions>
+			    <execution>
+			      <id>enforce-versions</id>
+			      <phase>validate</phase>
+			      <goals>
+				<goal>enforce</goal>
+			      </goals>
+			      <configuration>
+				<rules>
+				  <requireJavaVersion>
+				    <version>1.8.0-40</version>
+				  </requireJavaVersion>
+				</rules>
+			      </configuration>
+			    </execution>
+			  </executions>
+			</plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
This documents the minimal JDK version in the readme and stops
Maven if the wrong Java version is used.

Thanks to @mauricioaniche for alerting me of this.